### PR TITLE
解决$headers['Pos']未定义的bug

### DIFF
--- a/src/HttpSQS.php
+++ b/src/HttpSQS.php
@@ -283,7 +283,7 @@ class HttpSQS
         $body = substr($rawHeaders, $headerSize);
 
         $result = array(
-            'pos' => $headers['Pos'],
+            'pos' => isset($headers['Pos'])?$headers['Pos']:0,
             'data'=> $body
         );
         return $result;


### PR DESCRIPTION
当某个队列还未创建的时候，调用status方法会有$headers['Pos']未定义的报错。
